### PR TITLE
Fixed download issue in Linux

### DIFF
--- a/lib/kindlerb.rb
+++ b/lib/kindlerb.rb
@@ -35,13 +35,16 @@ module Kindlerb
     compressed_file = case RbConfig::CONFIG['host_os']
     when /mac|darwin/i
       extract = 'unzip '
+      extract_suffix = ' -d '
       "KindleGen_Mac_i386_v2_9.zip"
     when /linux|cygwin/i
       extract = 'tar zxf '
+      extract_suffix = ' '
       "kindlegen_linux_2.6_i386_v2_9.tar.gz"
     when /mingw32/i
       windows = true
       extract = 'unzip '
+      extract_suffix = ' -d '
       executable_filename = 'kindlegen.exe'
       "kindlegen_win32_v2_9.zip"
     else
@@ -57,7 +60,7 @@ module Kindlerb
     end
     system 'curl ' + url + ' -o ' + ext_dir + compressed_file
     puts "Kindlegen downloaded: " + ext_dir + compressed_file
-    system extract + ext_dir + compressed_file + ' -d ' + ext_dir
+    system extract + ext_dir + compressed_file + extract_suffix + ext_dir
 
     # Move the executable_filename into gem's /bin folder
     unless File.directory?(bin_dir)

--- a/lib/kindlerb.rb
+++ b/lib/kindlerb.rb
@@ -39,7 +39,7 @@ module Kindlerb
       "KindleGen_Mac_i386_v2_9.zip"
     when /linux|cygwin/i
       extract = 'tar zxf '
-      extract_suffix = ' '
+      extract_suffix = ' -C '
       "kindlegen_linux_2.6_i386_v2_9.tar.gz"
     when /mingw32/i
       windows = true

--- a/lib/kindlerb/version.rb
+++ b/lib/kindlerb/version.rb
@@ -1,3 +1,3 @@
 module Kindlerb
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Download was failing on linux due to `tar` command not accepting `-d` flag, to be able to extract to specific destination `-C` was needed. Bumped version one patch.